### PR TITLE
Add redis support to nextcloud role

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -259,3 +259,7 @@ nextcloud_hsts_preload_enabled: false
 # See the `collabora-online` role.
 nextcloud_collabora_app_wopi_url: ''
 nextcloud_collabora_app_wopi_allowlist: '10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16'
+
+# Redis intergration.
+nextcloud_redis_hostname: ''
+nextcloud_redis_port: 6379

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,4 +1,4 @@
-{% if nextcloud_redis_hostname  != '' %}
+{% if nextcloud_redis_hostname %}
 REDIS_HOST={{ nextcloud_redis_hostname }}
 REDIS_HOST_PORT={{ nextcloud_redis_port }}
 {% endif %}

--- a/templates/env.j2
+++ b/templates/env.j2
@@ -1,1 +1,6 @@
+{% if nextcloud_redis_hostname  != '' %}
+REDIS_HOST={{ nextcloud_redis_hostname }}
+REDIS_HOST_PORT={{ nextcloud_redis_port }}
+{% endif %}
+
 {{ nextcloud_container_additional_environment_variables }}


### PR DESCRIPTION
Adds support for redis without changing `nextcloud_container_additional_environment_variables`.