### PR TITLE
Correct file location for where {{ nextcloud_container_labels_additio…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -246,7 +246,7 @@ nextcloud_container_labels_traefik_http_middlewares_auto: []
 nextcloud_container_labels_traefik_http_middlewares_custom: []
 
 # nextcloud_container_labels_additional_labels contains a multiline string with additional labels to add to the container label file.
-# See `roles/custom/nextcloud/templates/labels.j2` for details.
+# See `../templates/labels.j2` for details.
 #
 # Example:
 # nextcloud_container_labels_additional_labels: |


### PR DESCRIPTION
…nal_labels }} is included

(Currently there are no actual "details" there, other than the location of the reference.)