### PR TITLE
Custom image is always used

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -145,7 +145,7 @@ nextcloud_container_image_registry_prefix: docker.io/
 nextcloud_container_image_customized: "localhost/nextcloud:{{ nextcloud_container_image_tag }}-customized"
 
 # nextcloud_container_image_final holds the name of the Nextcloud image to run depending on whether or not customizations are enabled.
-nextcloud_container_image_final: "{{ nextcloud_container_image_customized if nextcloud_container_image_customizations_enabled else nextcloud_container_image }}"
+nextcloud_container_image_final: "{{ nextcloud_container_image_customized if nextcloud_container_image_customizations_enabled | bool else nextcloud_container_image }}"
 
 # A list of extra arguments to pass to the container
 nextcloud_container_extra_arguments: []


### PR DESCRIPTION
As `nextcloud_container_image_customizations_enabled` is a string, without bool casting the conditional is always true which `causes nextcloud_container_image_customized` being used.