### PR TITLE
added optional systemd service + timer for nextcloud app updates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -447,7 +447,7 @@ nextcloud_cron_schedule: '*:0/15:0'
 
 #enable auto updates for nextcloud apps
 nextcloud_auto_app_update_enabled: false
-# nextcloud_cauto_app_update_schedule contains a systemd OnCalendar definition which controls how often `app-update.timer` runs
+# nextcloud_auto_app_update_schedule contains a systemd OnCalendar definition which controls how often `app-update.timer` runs
 # The default value means 'every day at 00:00'.
 # Learn more here: https://man.archlinux.org/man/systemd.time.7
 nextcloud_auto_app_update_schedule: '*-*-* 00:00:00'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -445,6 +445,13 @@ nextcloud_config_additional_parameters: []
 # Learn more here: https://man.archlinux.org/man/systemd.time.7
 nextcloud_cron_schedule: '*:0/15:0'
 
+#enable auto updates for nextcloud apps
+nextcloud_auto_app_update_enabled: false
+# nextcloud_cauto_app_update_schedule contains a systemd OnCalendar definition which controls how often `app-update.timer` runs
+# The default value means 'every day at 00:00'.
+# Learn more here: https://man.archlinux.org/man/systemd.time.7
+nextcloud_auto_app_update_schedule: '*-*-* 00:00:00'
+
 # Specifies the value of the `X-XSS-Protection` header
 # Stops pages from loading when they detect reflected cross-site scripting (XSS) attacks.
 #

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -95,12 +95,22 @@
 
 - when: "nextcloud_auto_app_update_enabled | bool"
   block:
-    name: Ensure Nextcloud app update systemd services installed
-    ansible.builtin.template:
-      src: "{{ role_path }}/templates/systemd/{{ item }}.j2"
-      dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ nextcloud_identifier }}-{{ item }}"
-      mode: 0640
-    with_items:
-      - app-update.service
-      - app-update.timer
+    - name: Ensure Nextcloud app update systemd services installed
+      ansible.builtin.template:
+        src: "{{ role_path }}/templates/systemd/{{ item }}.j2"
+        dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ nextcloud_identifier }}-{{ item }}"
+        mode: 0640
+      with_items:
+        - app-update.service
+        - app-update.timer
+
+- when: "not nextcloud_auto_app_update_enabled | bool"
+  block:
+    - name: Ensure Nextcloud systemd app update services do not exists
+      ansible.builtin.file:
+        path: "{{ devture_systemd_docker_base_systemd_path }}/{{ nextcloud_identifier }}-{{ item }}"
+        state: absent
+      with_items:
+        - app-update.service
+        - app-update.timer
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -92,3 +92,15 @@
     - server.service
     - cron.service
     - cron.timer
+
+- when: "nextcloud_auto_app_update_enabled | bool"
+  block:
+    name: Ensure Nextcloud app update systemd services installed
+    ansible.builtin.template:
+      src: "{{ role_path }}/templates/systemd/{{ item }}.j2"
+      dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ nextcloud_identifier }}-{{ item }}"
+      mode: 0640
+    with_items:
+      - app-update.service
+      - app-update.timer
+

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -17,6 +17,8 @@
         - server.service
         - cron.service
         - cron.timer
+        - app-update.service
+        - app-update.timer
 
     - name: Ensure Nextcloud systemd services do not exists
       ansible.builtin.file:
@@ -26,6 +28,8 @@
         - server.service
         - cron.service
         - cron.timer
+        - app-update.service
+        - app-update.timer
 
     - name: Ensure Nextcloud path doesn't exist
       ansible.builtin.file:

--- a/templates/systemd/app-update.service.j2
+++ b/templates/systemd/app-update.service.j2
@@ -1,0 +1,6 @@
+[Unit]
+Description=Runs app updates For Nextcloud ({{ nextcloud_identifier }})
+
+[Service]
+Type=oneshot
+ExecStart={{ devture_systemd_docker_base_host_command_docker }} exec {{ nextcloud_identifier }}-server php /var/www/html/occ app:update --all --no-interaction

--- a/templates/systemd/app-update.timer.j2
+++ b/templates/systemd/app-update.timer.j2
@@ -1,0 +1,9 @@
+[Unit]
+Description=Periodically update the apps for Nextcloud ({{ nextcloud_identifier }})
+
+[Timer]
+Unit={{ nextcloud_identifier }}-app-update.service
+OnCalendar={{ nextcloud_auto_app_update_schedule }}
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
the auto update service + timer was not installed per default, only if nextcloud_auto_app_update_enabled is set to true.
You could also think about always installing the update service without a timer so that you can install the apps manually relatively easily via cli.

Due to a lack of app updates, I could not test the command in connection with my Mash-Nextcloud instance, in an old instance it worked as a cronjob without any problems.