### PR TITLE
Update adjust_config.yml - remove type for preview generator

### DIFF
--- a/tasks/adjust_config.yml
+++ b/tasks/adjust_config.yml
@@ -30,22 +30,19 @@
     - name: Adjust Nextcloud configuration values related to preview generator
       ansible.builtin.command:
           cmd: |-
-            docker exec --user={{ nextcloud_uid }}:{{ nextcloud_gid }} {{ nextcloud_identifier }}-server php /var/www/html/occ {{ item.appType }} --type={{ item.type }} --value={{ item.value }} -- {{ item.appConfig }} {{ item.configName }}
+            docker exec --user={{ nextcloud_uid }}:{{ nextcloud_gid }} {{ nextcloud_identifier }}-server php /var/www/html/occ {{ item.appType }} --value={{ item.value }} -- {{ item.appConfig }} {{ item.configName }}
       with_items:
         - appType: "config:system:set"
           appConfig: ""
           configName: "preview_max_x"
-          type: "string"
           value: "{{ nextcloud_preview_preview_max_x }}"
         - appType: "config:system:set"
           appConfig: ""
           configName: "preview_max_y"
-          type: "string"
           value: "{{ nextcloud_preview_preview_max_y }}"
         - appType: "config:app:set"
           appConfig: "preview"
           configName: "jpeg_quality"
-          type: int
           value: "{{ nextcloud_preview_app_jpeg_quality }}"
 
     - name: "Check if {{ nextcloud_preview_first_run_finished_filename }} exists"


### PR DESCRIPTION
adjust-nextcloud-config tags is returning an error `Unknown type integer`  with type `int` for `jpeg_quality`.


adjust-nextcloud-config tags is returning an error `You are about to set config value preview/jpeg_quality as INTEGER. This might break thing, affect performance on your instance or its security!`  with type `integer` for `jpeg_quality`.


This workaround proposes to remove the "type=" as the playbook works well without