### PR TITLE
Align database credentials order with the UI on installation wizard

### DIFF
--- a/tasks/print_db_credentials.yml
+++ b/tasks/print_db_credentials.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 ---
 
 - name: Print Nextcloud DB credentials

--- a/tasks/print_db_credentials.yml
+++ b/tasks/print_db_credentials.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+# SPDX-FileCopyrightText: 2025 Suguru Hirahara
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -7,9 +8,8 @@
 - name: Print Nextcloud DB credentials
   ansible.builtin.debug:
     msg: >-
-      Your Nextcloud database information is:
-      Host (`{{ nextcloud_database_hostname }}`),
-      Port (`{{ nextcloud_database_port }}`),
-      Database Name (`{{ nextcloud_database_name }}`),
-      Database Username (`{{ nextcloud_database_username }}`),
-      Database Password (`{{ nextcloud_database_password }}`)
+      Here is your Nextcloud database information:
+      Database account (`{{ nextcloud_database_username }}`),
+      Database password (`{{ nextcloud_database_password }}`),
+      Database name (`{{ nextcloud_database_name }}`),
+      Database host (`{{ nextcloud_database_hostname }}:{{ nextcloud_database_port }}`)


### PR DESCRIPTION
Here is the current (`v31.0.2`) UI on the installation wizard:

![nextcloud](https://github.com/user-attachments/assets/0cfb641f-f0ac-48e8-b08e-dee2bd7929c7)

This PR changes the order of the database credentials output by running `print-nextcloud-db-credentials` to have it aligned with the UI, as below:

![1](https://github.com/user-attachments/assets/2367fc17-8740-41e0-8b1d-e796a6b85016)
