### PR TITLE
Add the instruction about setting longer timeout configuration for traefik.yml

### DIFF
--- a/docs/configuring-nextcloud.md
+++ b/docs/configuring-nextcloud.md
@@ -11,10 +11,13 @@ SPDX-FileCopyrightText: 2022 Warren Bailey
 SPDX-FileCopyrightText: 2023 - 2024 MASH project contributors
 SPDX-FileCopyrightText: 2023 Antonis Christofides
 SPDX-FileCopyrightText: 2023 Felix Stupp
-SPDX-FileCopyrightText: 2023 Gergely Horváth
+SPDX-FileCopyrightText: 2023 - 2024 Gergely Horváth
+SPDX-FileCopyrightText: 2023 Julian-Samuel Gebühr
+SPDX-FileCopyrightText: 2023 Niels Bouma
 SPDX-FileCopyrightText: 2023 Pierre 'McFly' Marty
 SPDX-FileCopyrightText: 2024 - 2025 Suguru Hirahara
 SPDX-FileCopyrightText: 2024 Philipp Homann
+SPDX-FileCopyrightText: 2025 IUCCA
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
@@ -87,6 +90,31 @@ For other settings, check variables such as `nextcloud_database_mysql_*` and `ne
 
 >[!NOTE]
 > It is possible to convert a SQLite database to a MySQL, MariaDB or PostgreSQL database with the Nextcloud command line tool. See [this page](docs.nextcloud.com/server/latest/admin_manual/configuration_database/db_conversion.html) on the documentation for details.
+
+### Adjusting Traefik configuration for long-running uploads (optional; recommended)
+
+We recommend **adjusting your Traefik configuration** to allow long-running uploads (which may be necessary for uploading large files over slow connections to Nextcloud).
+
+```yml
+########################################################################
+#                                                                      #
+# traefik                                                              #
+#                                                                      #
+########################################################################
+
+# Your regular Traefik configuration here.
+
+# Increase some timeouts to allow for longer image uploads for Nextcloud.
+traefik_config_entrypoint_web_transport_respondingTimeouts_readTimeout: 1800s
+traefik_config_entrypoint_web_transport_respondingTimeouts_writeTimeout: 1800s
+traefik_config_entrypoint_web_transport_respondingTimeouts_idleTimeout: 1800s
+
+########################################################################
+#                                                                      #
+# /traefik                                                             #
+#                                                                      #
+########################################################################
+```
 
 ### Editing default configuration parameters (optional)
 


### PR DESCRIPTION
cf. https://github.com/mother-of-all-self-hosting/ansible-role-nextcloud/issues/69 and https://github.com/mother-of-all-self-hosting/mash-playbook/issues/625

Reuse https://github.com/mother-of-all-self-hosting/ansible-role-nextcloud/blob/2ce0bb334a0d3627baaf0bdfcef78c7a0df8c93f/docs/configuring-nextcloud.md

Not tested, but it should be informative for those who experience the issue.