### PR TITLE
Fix OIDC claim value command quoting

### DIFF
--- a/tasks/oidc.yml
+++ b/tasks/oidc.yml
@@ -34,7 +34,7 @@
           {{ devture_systemd_docker_base_host_command_docker }} exec
           --user={{ nextcloud_uid }}:{{ nextcloud_gid }}
           {{ nextcloud_identifier }}-server
-          php /var/www/html/occ config:app:set oidc {{ item }} --value "{{ nextcloud_oidc_claim_value }}
+          php /var/www/html/occ config:app:set oidc {{ item }} --value "{{ nextcloud_oidc_claim_value }}"
       vars:
         nextcloud_oidc_claim_value: "{{ lookup('vars', 'nextcloud_oidc_' ~ item, default='gid') }}"
       register: nextcloud_oidc_claim_value_result


### PR DESCRIPTION
Restore the missing closing quote around the OIDC claim value.

The quote was dropped while the Docker commands were reformatted in `157e11f`. When `nextcloud_app_oidc_enabled` is enabled and the OIDC-provider configuration task runs, `ansible.builtin.command` fails with:

`No closing quotation`

The failure occurs after the OIDC Provider app has been enabled but before its claim types are configured.