### PR TITLE
fix: add type=int to php occ command in adjust_config.yml

### DIFF
--- a/tasks/adjust_config.yml
+++ b/tasks/adjust_config.yml
@@ -127,7 +127,7 @@
           {{ devture_systemd_docker_base_host_command_docker }} exec
           --user={{ nextcloud_uid }}:{{ nextcloud_gid }}
           {{ nextcloud_identifier }}-server
-          php /var/www/html/occ {{ item.appType }} --value={{ item.value }} -- {{ item.appConfig }} {{ item.configName }}
+          php /var/www/html/occ {{ item.appType }} --value={{ item.value }} --type=int {{ item.appConfig }} {{ item.configName }}
       with_items:
         - appType: "config:system:set"
           appConfig: ""


### PR DESCRIPTION
This PR propose to set the type to integer (instead of default string) for preview related variables